### PR TITLE
feat: refactor refresh token logic

### DIFF
--- a/src/space-connector/api.ts
+++ b/src/space-connector/api.ts
@@ -8,8 +8,6 @@ const ACCESS_TOKEN_KEY = 'spaceConnector/accessToken';
 const REFRESH_TOKEN_KEY = 'spaceConnector/refreshToken';
 const REFRESH_URL = '/identity/token/refresh';
 
-const CHECK_TOKEN_TIME = 1000 * 30;
-
 export class APIError extends Error {
     status: number;
 
@@ -73,8 +71,6 @@ class API {
 
         this.loadToken();
         this.setAxiosInterceptors();
-
-        setInterval(() => this.getActivatedToken(), CHECK_TOKEN_TIME);
     }
 
     private loadToken(): void {
@@ -102,6 +98,7 @@ class API {
 
     async refreshAccessToken(): Promise<void> {
         try {
+            console.log('refresh');
             const response = await this.refreshInstance.post(REFRESH_URL);
             this.setToken(response.data.access_token, response.data.refresh_token);
         } catch (e) {

--- a/src/space-connector/api.ts
+++ b/src/space-connector/api.ts
@@ -148,7 +148,6 @@ class API {
     }
 
     static getCurrentTime(): number {
-        console.log('time', Math.floor(Date.now() / 1000))
         return Math.floor(Date.now() / 1000);
     }
 

--- a/src/space-connector/api.ts
+++ b/src/space-connector/api.ts
@@ -118,10 +118,6 @@ class API {
             if (!isTokenValid) {
                 await this.refreshAccessToken();
             }
-        } else {
-            this.flushToken();
-            this.sessionTimeoutCallback();
-            throw new Error('Session has expired.');
         }
     }
 

--- a/src/space-connector/api.ts
+++ b/src/space-connector/api.ts
@@ -98,7 +98,6 @@ class API {
 
     async refreshAccessToken(): Promise<void> {
         try {
-            console.log('refresh');
             const response = await this.refreshInstance.post(REFRESH_URL);
             this.setToken(response.data.access_token, response.data.refresh_token);
         } catch (e) {

--- a/src/space-connector/index.ts
+++ b/src/space-connector/index.ts
@@ -39,8 +39,8 @@ export class SpaceConnector {
         SpaceConnector.instance.api.flushToken();
     }
 
-    static get refreshToken(): string|undefined {
-        return SpaceConnector.instance.api.getRefreshToken();
+    static getActivatedToken(): Promise<void> {
+        return SpaceConnector.instance.api.getActivatedToken();
     }
 
     static get isTokenAlive(): boolean {

--- a/src/space-connector/index.ts
+++ b/src/space-connector/index.ts
@@ -6,6 +6,8 @@ import { SessionTimeoutCallback, APIInfo, MockInfo } from '@src/space-connector/
 
 const API_REFLECTION_URL = '/api/reflection';
 
+const CHECK_TOKEN_TIME = 1000 * 30;
+
 export class SpaceConnector {
     private static instance: SpaceConnector;
 
@@ -15,6 +17,7 @@ export class SpaceConnector {
 
     constructor(endpoint: string, sessionTimeoutCallback: SessionTimeoutCallback = () => undefined, mockInfo: MockInfo) {
         this.api = new API(endpoint, sessionTimeoutCallback, mockInfo);
+        setInterval(() => this.api.getActivatedToken(), CHECK_TOKEN_TIME);
     }
 
     static async init(endpoint: string, sessionTimeoutCallback?: SessionTimeoutCallback, mockInfo: MockInfo = {}): Promise<void> {
@@ -37,10 +40,6 @@ export class SpaceConnector {
 
     static flushToken(): void {
         SpaceConnector.instance.api.flushToken();
-    }
-
-    static getActivatedToken(): Promise<void> {
-        return SpaceConnector.instance.api.getActivatedToken();
     }
 
     static get isTokenAlive(): boolean {


### PR DESCRIPTION
### 작업 개요
refresh token 로직 변경

### 작업 분류
- [x] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
30초에 한 번 check token 함수를 호출하여 false일 시에 refreshAccessToken으로 토큰을 연장해주는 로직을 구현(기존엔 401 에러 발생 시 토큰 연장)


### 생각해볼 문제

