### PR TITLE
fix: remove mock mode from api and change mock mode usage in SpaceConnector

### DIFF
--- a/src/space-connector/api.ts
+++ b/src/space-connector/api.ts
@@ -17,9 +17,6 @@ const REFRESH_TOKEN_KEY = 'spaceConnector/refreshToken';
 const REFRESH_URL = '/identity/token/refresh';
 const IS_REFRESHING_KEY = 'spaceConnector/isRefreshing';
 
-const setMockMode = (request: AxiosRequestConfig, mockEndpoint?: string) => {
-    if (mockEndpoint) request.baseURL = mockEndpoint;
-};
 
 class API {
     instance: AxiosInstance;
@@ -38,11 +35,9 @@ class API {
         }
     };
 
-    private mockInfo: MockInfo = {};
 
-    constructor(baseURL: string, sessionTimeoutCallback: SessionTimeoutCallback, mockInfo: MockInfo) {
+    constructor(baseURL: string, sessionTimeoutCallback: SessionTimeoutCallback) {
         this.sessionTimeoutCallback = sessionTimeoutCallback;
-        this.mockInfo = mockInfo;
 
         const axiosConfig = this.getAxiosConfig(baseURL);
         this.instance = axios.create(axiosConfig);
@@ -146,10 +141,6 @@ class API {
             this.defaultAxiosConfig.baseURL = baseURL;
         }
 
-        if (this.mockInfo.all) {
-            setMockMode(this.defaultAxiosConfig, this.mockInfo.endpoint);
-        }
-
         return this.defaultAxiosConfig;
     }
 
@@ -181,10 +172,6 @@ class API {
             // Set the access token
             const storedAccessToken = window.localStorage.getItem(ACCESS_TOKEN_KEY);
             request.headers.Authorization = `Bearer ${storedAccessToken}`;
-            // Set mock mode
-            if (request.headers.MOCK_MODE) {
-                setMockMode(request, this.mockInfo.endpoint);
-            }
 
             return request;
         });

--- a/src/space-connector/api.ts
+++ b/src/space-connector/api.ts
@@ -4,7 +4,7 @@ import axios, {
 import jwt from 'jsonwebtoken';
 import {
     AxiosPostResponse,
-    MockInfo, SessionTimeoutCallback
+    SessionTimeoutCallback
 } from '@src/space-connector/type';
 import {
     APIError, AuthenticationError,
@@ -16,7 +16,6 @@ const ACCESS_TOKEN_KEY = 'spaceConnector/accessToken';
 const REFRESH_TOKEN_KEY = 'spaceConnector/refreshToken';
 const REFRESH_URL = '/identity/token/refresh';
 const IS_REFRESHING_KEY = 'spaceConnector/isRefreshing';
-
 
 class API {
     instance: AxiosInstance;
@@ -34,7 +33,6 @@ class API {
             'Content-Type': 'application/json'
         }
     };
-
 
     constructor(baseURL: string, sessionTimeoutCallback: SessionTimeoutCallback) {
         this.sessionTimeoutCallback = sessionTimeoutCallback;


### PR DESCRIPTION
### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 작업 내용
#### `SpaceConnector`의 mock mode를 사용하기 & 유지보수 하기가 까다로워, 아래처럼 변경하였습니다.
##### 1. api instance까지 내려가서 인터셉터를 통해 url을 변경하던 부분을, space connector의 api handler에서 관장하도록 리팩토링 하였습니다. 
##### 2. 기존에는 mock mode의 경우  `config.headers`에 `MOCK_MODE: true`를 주어야 했습니다. 이 방식이 불편하여, axios config를 확장하여 `mockMode`, `mockPath`를 추가하였습니다.

```typescript
interface MockRequestConfig extends AxiosRequestConfig {
    mockMode?: boolean;
    mockPath?: string;
}
```

- mockMode
- mockPath: postman에 여러 예제파일이 존재하는 경우, query params를 통해 특정 예제 파일을 응답으로 받도록 할 수 있습니다. [postaman example 작성](https://learning.postman.com/docs/sending-requests/examples/)

![image](https://user-images.githubusercontent.com/26986739/147528821-fe3654ae-396a-4d4f-860b-3d3e939e9fd2.png)


###### 사용방식
```typescript
SpaceConnector.client.addOns.pageSchema.get({
...       
}, {
    mockMode: true,
    mockPath: '?schema=widget',
});
```



### 생각해볼 문제
