### PR TITLE
feat: add reference store to queryHelper for labeling

### DIFF
--- a/src/component-util/query-search/type.ts
+++ b/src/component-util/query-search/type.ts
@@ -33,6 +33,7 @@ export interface KeyItem {
     name: any;
     dataType?: KeyDataType;
     operators?: OperatorType[];
+    reference?: string;
 }
 
 export interface QueryItem {

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -25,6 +25,9 @@ dayjs.extend(utc);
 dayjs.extend(tz);
 
 interface QueryTag extends Tag, QueryItem {}
+type ReferenceMap = Record<string, { label: string; name: string }>;
+type ReferenceStore = Record<string, ReferenceMap>;
+
 const filterToQueryTag = (
     filter: { k?: string; v: QueryStoreFilterValue; o?: RawQueryOperator },
     keyMap: Record<string, KeyItem>,
@@ -55,8 +58,9 @@ const filterToQueryTag = (
     }
     /* general case */
     const reference = keyMap[filter.k]?.reference;
-    const referenceStoreValue = referenceStore ? referenceStore.value : undefined;
-    const label = (reference && referenceStoreValue) ? referenceStoreValue[reference][filter.v.toString()]?.label : filter.v.toString();
+    const referenceStoreValue = referenceStore?.value;
+    const selectedReferenceStore = (reference && referenceStoreValue) ? ((referenceStoreValue[reference]) ?? undefined) : undefined;
+    const label = (selectedReferenceStore) ? selectedReferenceStore[filter.v.toString()]?.label : filter.v.toString();
     return {
         key: keyMap[filter.k] || { label: filter.k, name: filter.k },
         value: { label, name: filter.v },
@@ -105,7 +109,7 @@ const filterToApiQueryFilter = (_filters: QueryStoreFilter[], timezone = 'UTC') 
 export class QueryHelper {
     private static timezone: ComputedRef<string> | undefined;
 
-    private static referenceStore: ComputedRef<Object> | undefined;
+    private static referenceStore: ComputedRef<ReferenceStore> | undefined;
 
     private _keyMap: Record<string, KeyItem> = {};
 
@@ -113,9 +117,9 @@ export class QueryHelper {
 
     private _orFilters: QueryStoreFilter[] = [];
 
-    static init(timezone: ComputedRef<string>, referenceStore: ComputedRef<Object>) {
+    static init(timezone: ComputedRef<string>, referenceStore?: ComputedRef<ReferenceStore>) {
         QueryHelper.timezone = timezone;
-        QueryHelper.referenceStore = referenceStore ?? undefined;
+        QueryHelper.referenceStore = referenceStore;
     }
 
     setKeyItemSets(keyItemSets: KeyItemSet[]): this {

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -25,7 +25,11 @@ dayjs.extend(utc);
 dayjs.extend(tz);
 
 interface QueryTag extends Tag, QueryItem {}
-const filterToQueryTag = (filter: { k?: string; v: QueryStoreFilterValue; o?: RawQueryOperator }, keyMap: Record<string, KeyItem>): QueryTag | null => {
+const filterToQueryTag = (
+    filter: { k?: string; v: QueryStoreFilterValue; o?: RawQueryOperator },
+    keyMap: Record<string, KeyItem>,
+    referenceStore: ComputedRef<Object> | undefined
+): QueryTag | null => {
     if (filter.k === undefined || filter.k === null) {
         /* no key case */
         if (filter.v === null || filter.v === undefined) return null;
@@ -50,9 +54,12 @@ const filterToQueryTag = (filter: { k?: string; v: QueryStoreFilterValue; o?: Ra
         };
     }
     /* general case */
+    const reference = keyMap[filter.k]?.reference;
+    const referenceStoreValue = referenceStore ? referenceStore.value : undefined;
+    const label = (reference && referenceStoreValue) ? referenceStoreValue[reference][filter.v.toString()]?.label : filter.v.toString();
     return {
         key: keyMap[filter.k] || { label: filter.k, name: filter.k },
-        value: { label: filter.v.toString(), name: filter.v },
+        value: { label, name: filter.v },
         operator: datetimeRawQueryOperatorToQueryTagOperatorMap[filter.o as string] || filter.o || '' as OperatorType
     };
 };
@@ -98,14 +105,17 @@ const filterToApiQueryFilter = (_filters: QueryStoreFilter[], timezone = 'UTC') 
 export class QueryHelper {
     private static timezone: ComputedRef<string> | undefined;
 
+    private static referenceStore: ComputedRef<Object> | undefined;
+
     private _keyMap: Record<string, KeyItem> = {};
 
     private _filters: QueryStoreFilter[] = [];
 
     private _orFilters: QueryStoreFilter[] = [];
 
-    static init(timezone: ComputedRef<string>) {
+    static init(timezone: ComputedRef<string>, referenceStore: ComputedRef<Object>) {
         QueryHelper.timezone = timezone;
+        QueryHelper.referenceStore = referenceStore ?? undefined;
     }
 
     setKeyItemSets(keyItemSets: KeyItemSet[]): this {
@@ -218,11 +228,11 @@ export class QueryHelper {
         this._filters.forEach((f) => {
             if (Array.isArray(f.v)) {
                 f.v.forEach((v) => {
-                    const tag = filterToQueryTag({ k: f.k, v, o: f.o }, this._keyMap);
+                    const tag = filterToQueryTag({ k: f.k, v, o: f.o }, this._keyMap, QueryHelper.referenceStore);
                     if (tag) res.push(tag);
                 });
             } else {
-                const tag = filterToQueryTag(f as any, this._keyMap);
+                const tag = filterToQueryTag(f as any, this._keyMap, QueryHelper.referenceStore);
                 if (tag) res.push(tag);
             }
         });


### PR DESCRIPTION
### To Reviewers
- [ ] Skip

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 작업 내용
쿼리태그에 리소스별 ID가 아닌 라벨을 표시하기위해 QueryHelper 클래스에 referenceStore가 추가되었습니다.
keyItem에 reference속성이 있는경우에 해당 레퍼런스 스토어를 참조하여 라벨로 반환합니다.

- **console에 추가작업이 필요합니다.**
    - QueryStore init에서 레퍼런스스토어들 추가
    - makeQuerySearchPropsWithSearchSchema에서 reference 속성도 추가되도록 수정
### 생각해볼 문제
