### PR TITLE
feat: add new spaceconnector error instance

### DIFF
--- a/src/space-connector/error.ts
+++ b/src/space-connector/error.ts
@@ -79,3 +79,5 @@ export const isInstanceOfBadRequestError = (e: unknown): e is BadRequestError =>
 export const isInstanceOfAuthenticationError = (e: unknown): e is AuthenticationError => e instanceof AuthenticationError;
 
 export const isInstanceOfAuthorizationError = (e: unknown): e is AuthorizationError => e instanceof AuthorizationError;
+
+export const isInstanceOfSyntaxError = (e: unknown): e is SyntaxError => e instanceof SyntaxError;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 작업 내용
text-editor 에서 작성된 string 을 JSON.parse 후 API 파라미터로 전달해야할 때 Syntax error 가 발생합니다.
이를 errorHandler 에서 캐치할 수 있도록 syntaxerror instance 를 추가하였습니다.

### 생각해볼 문제
